### PR TITLE
expose trade status through the api

### DIFF
--- a/fut/core.py
+++ b/fut/core.py
@@ -50,44 +50,61 @@ def baseId(resource_id, return_version=False):
     return abs(resource_id)
 
 
-def itemParse(item_data):
+def itemParse(item_data, full=True):
     """Parser for item data. Returns nice dictionary."""
-    return {
-        'tradeId':           item_data.get('tradeId'),
-        'buyNowPrice':       item_data.get('buyNowPrice'),
-        'tradeState':        item_data.get('tradeState'),
-        'bidState':          item_data.get('bidState'),
-        'startingBid':       item_data.get('startingBid'),
-        'id':                item_data['itemData']['id'],
-        'timestamp':         item_data['itemData']['timestamp'],  # auction start
-        'rating':            item_data['itemData']['rating'],
-        'assetId':           item_data['itemData']['assetId'],
-        'resourceId':        item_data['itemData']['resourceId'],
-        'itemState':         item_data['itemData']['itemState'],
-        'rareflag':          item_data['itemData']['rareflag'],
-        'formation':         item_data['itemData']['formation'],
-        'leagueId':          item_data['itemData'].get('leagueId'),
-        'injuryType':        item_data['itemData'].get('injuryType'),
-        'injuryGames':       item_data['itemData']['injuryGames'],
-        'lastSalePrice':     item_data['itemData']['lastSalePrice'],
-        'fitness':           item_data['itemData']['fitness'],
-        'training':          item_data['itemData']['training'],
-        'suspension':        item_data['itemData']['suspension'],
-        'contract':          item_data['itemData']['contract'],
-        # 'position':         item_data['itemData']['preferredPosition'],
-        'playStyle':         item_data['itemData'].get('playStyle'),  # used only for players
-        'discardValue':      item_data['itemData']['discardValue'],
-        'itemType':          item_data['itemData']['itemType'],
-        'cardType':          item_data['itemData'].get("cardsubtypeid"),  # used only for cards
-        'owners':            item_data['itemData']['owners'],
-        'offers':            item_data.get('offers'),
-        'currentBid':        item_data.get('currentBid'),
-        'expires':           item_data.get('expires'),  # seconds left
-        'sellerEstablished': item_data.get('sellerEstablished'),
-        'sellerId':          item_data.get('sellerId'),
-        'sellerName':        item_data.get('sellerName'),
-        'watched':           item_data.get('watched'),
-    }
+    if full:
+        return {
+            'tradeId':           item_data.get('tradeId'),
+            'buyNowPrice':       item_data.get('buyNowPrice'),
+            'tradeState':        item_data.get('tradeState'),
+            'bidState':          item_data.get('bidState'),
+            'startingBid':       item_data.get('startingBid'),
+            'id':                item_data['itemData']['id'],
+            'timestamp':         item_data['itemData']['timestamp'],  # auction start
+            'rating':            item_data['itemData']['rating'],
+            'assetId':           item_data['itemData']['assetId'],
+            'resourceId':        item_data['itemData']['resourceId'],
+            'itemState':         item_data['itemData']['itemState'],
+            'rareflag':          item_data['itemData']['rareflag'],
+            'formation':         item_data['itemData']['formation'],
+            'leagueId':          item_data['itemData'].get('leagueId'),
+            'injuryType':        item_data['itemData'].get('injuryType'),
+            'injuryGames':       item_data['itemData']['injuryGames'],
+            'lastSalePrice':     item_data['itemData']['lastSalePrice'],
+            'fitness':           item_data['itemData']['fitness'],
+            'training':          item_data['itemData']['training'],
+            'suspension':        item_data['itemData']['suspension'],
+            'contract':          item_data['itemData']['contract'],
+            # 'position':         item_data['itemData']['preferredPosition'],
+            'playStyle':         item_data['itemData'].get('playStyle'),  # used only for players
+            'discardValue':      item_data['itemData']['discardValue'],
+            'itemType':          item_data['itemData']['itemType'],
+            'cardType':          item_data['itemData'].get("cardsubtypeid"),  # used only for cards
+            'owners':            item_data['itemData']['owners'],
+            'offers':            item_data.get('offers'),
+            'currentBid':        item_data.get('currentBid'),
+            'expires':           item_data.get('expires'),  # seconds left
+            'sellerEstablished': item_data.get('sellerEstablished'),
+            'sellerId':          item_data.get('sellerId'),
+            'sellerName':        item_data.get('sellerName'),
+            'watched':           item_data.get('watched'),
+        }
+    else:
+        return {
+            'tradeId':           item_data.get('tradeId'),
+            'buyNowPrice':       item_data.get('buyNowPrice'),
+            'tradeState':        item_data.get('tradeState'),
+            'bidState':          item_data.get('bidState'),
+            'startingBid':       item_data.get('startingBid'),
+            'id':                item_data['itemData']['id'],
+            'offers':            item_data.get('offers'),
+            'currentBid':        item_data.get('currentBid'),
+            'expires':           item_data.get('expires'),  # seconds left
+            'sellerEstablished': item_data.get('sellerEstablished'),
+            'sellerId':          item_data.get('sellerId'),
+            'sellerName':        item_data.get('sellerName'),
+            'watched':           item_data.get('watched'),
+        }
 
 '''  # different urls (platforms)
 def cardInfo(resource_id):
@@ -525,7 +542,7 @@ class Core(object):
 
     def bid(self, trade_id, bid):
         """Make a bid."""
-        rc = self.__get__(self.urls['fut']['TradeStatus'], params={'tradeIds': trade_id})['auctionInfo'][0]
+        rc = self.tradeStatus(trade_id)[0]
         if rc['currentBid'] < bid and self.credits >= bid:
             data = {'bid': bid}
             url = '{0}/{1}/bid'.format(self.urls['fut']['PostBid'], trade_id)
@@ -565,6 +582,14 @@ class Core(object):
         # TODO: ability to get full squad info (full=True)
         return self.squad(squad_id='list')
     '''
+
+    def tradeStatus(self, trade_id):
+        if not isinstance(trade_id, (list, tuple)):
+            trade_id = (trade_id,)
+        trade_id = (str(i) for i in trade_id)
+        params = {'itemdata': 'true', 'tradeIds': ','.join(trade_id)}
+        rc = self.__get__(self.urls['fut']['TradeStatus'], params=params)
+        return [itemParse(i, full=False) for i in rc['auctionInfo']]
 
     def tradepile(self):
         """Returns items in tradepile."""


### PR DESCRIPTION
The intent here is to enable us to only call searchAuctions a couple times and keep a list of tradeIds that we can check for updates on without having to add them to our watchlist.