### PR TITLE
[Feature] Show reason on login error

### DIFF
--- a/fut/core.py
+++ b/fut/core.py
@@ -477,10 +477,10 @@ class Core(object):
             self.logger.debug(rc.content)
             rc = rc.json()
             if rc['string'] != 'OK':  # we've got error
-                if 'Answers do not match' in rc['reason']:
-                    raise FutError(reason='Error during login process (invalid secret answer).')
-                else:
-                    raise UnknownError
+                # Known reasons:
+                # * invalid secret answer
+                # * No remaining attempt
+                raise FutError(reason='Error during login process (%s).' % (rc['reason']))
             self.r.headers['Content-Type'] = 'application/json'
         self.token = rc['token']
 


### PR DESCRIPTION
The response during login seems to always return a reason. The raised error can thereby be generalized to using the `reason` property instead of checking which case it matches.